### PR TITLE
feat: support --prompt-file across prompt-taking commands

### DIFF
--- a/cmd/diagram.go
+++ b/cmd/diagram.go
@@ -10,8 +10,9 @@ import (
 )
 
 var (
-	diagramType   string
-	diagramOutput string
+	diagramType       string
+	diagramOutput     string
+	diagramPromptFile string
 )
 
 var diagramCmd = &cobra.Command{
@@ -23,7 +24,7 @@ Examples:
   imagemage diagram "CI/CD pipeline with testing stages"
   imagemage diagram "microservices architecture" --type="architecture"
   imagemage diagram "user authentication flow" --type="flowchart"`,
-	Args: cobra.MinimumNArgs(1),
+	Args: cobra.MaximumNArgs(1),
 	RunE: runDiagram,
 }
 
@@ -32,10 +33,14 @@ func init() {
 
 	diagramCmd.Flags().StringVar(&diagramType, "type", "diagram", "Diagram type: flowchart, architecture, sequence, entity-relationship")
 	diagramCmd.Flags().StringVarP(&diagramOutput, "output", "o", ".", "Output directory")
+	addPromptFileFlag(diagramCmd, &diagramPromptFile)
 }
 
 func runDiagram(cmd *cobra.Command, args []string) error {
-	description := args[0]
+	description, err := resolvePrompt(optionalArg(args, 0), diagramPromptFile)
+	if err != nil {
+		return err
+	}
 
 	// Build prompt
 	prompt := fmt.Sprintf("Create a clear, professional %s diagram: %s. ", diagramType, description)

--- a/cmd/diagram.go
+++ b/cmd/diagram.go
@@ -23,7 +23,8 @@ var diagramCmd = &cobra.Command{
 Examples:
   imagemage diagram "CI/CD pipeline with testing stages"
   imagemage diagram "microservices architecture" --type="architecture"
-  imagemage diagram "user authentication flow" --type="flowchart"`,
+  imagemage diagram "user authentication flow" --type="flowchart"
+  imagemage diagram --prompt-file ./diagram.txt`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: runDiagram,
 }

--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -41,7 +41,10 @@ Examples:
   imagemage edit scene.png "put these people here" -i person1.png -i person2.png
 
   # Complex composition
-  imagemage edit office.png "add this person and this laptop" -i person.png -i laptop.png`,
+  imagemage edit office.png "add this person and this laptop" -i person.png -i laptop.png
+
+  # Read instruction from a file
+  imagemage edit photo.png --prompt-file ./instruction.txt`,
 	Args: cobra.RangeArgs(1, 2),
 	RunE: runEdit,
 }

--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -20,6 +20,7 @@ var (
 	editFrugal      bool
 	editForce       bool
 	editStorePrompt bool
+	editPromptFile  string
 )
 
 var editCmd = &cobra.Command{
@@ -41,7 +42,7 @@ Examples:
 
   # Complex composition
   imagemage edit office.png "add this person and this laptop" -i person.png -i laptop.png`,
-	Args: cobra.ExactArgs(2),
+	Args: cobra.RangeArgs(1, 2),
 	RunE: runEdit,
 }
 
@@ -55,11 +56,15 @@ func init() {
 	editCmd.Flags().BoolVarP(&editFrugal, "frugal", "f", false, "Use Nano Banana 2 (faster, cheaper, still supports 4K)")
 	editCmd.Flags().BoolVar(&editForce, "force", false, "Overwrite output file if it exists")
 	editCmd.Flags().BoolVar(&editStorePrompt, "store-prompt", false, "Store instruction in PNG metadata")
+	addPromptFileFlag(editCmd, &editPromptFile)
 }
 
 func runEdit(cmd *cobra.Command, args []string) error {
 	baseImagePath := args[0]
-	instruction := args[1]
+	instruction, err := resolvePrompt(optionalArg(args, 1), editPromptFile)
+	if err != nil {
+		return err
+	}
 
 	// Check if base image exists
 	if _, err := os.Stat(baseImagePath); os.IsNotExist(err) {

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -5,10 +5,7 @@ import (
 	"imagemage/pkg/filehandler"
 	"imagemage/pkg/gemini"
 	"imagemage/pkg/metadata"
-	"io"
-	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/spf13/cobra"
 )
@@ -62,11 +59,11 @@ func init() {
 	generateCmd.Flags().StringVar(&generateConfig, "config", "", "Path to config file (JSON) with style, colorScheme, additionalContext")
 	generateCmd.Flags().BoolVar(&generateForce, "force", false, "Overwrite existing files without confirmation")
 	generateCmd.Flags().BoolVar(&generateStorePrompt, "store-prompt", false, "Store prompt in PNG metadata for reproducibility")
-	generateCmd.Flags().StringVar(&generatePromptFile, "prompt-file", "", "Read prompt from a file (use '-' for stdin)")
+	addPromptFileFlag(generateCmd, &generatePromptFile)
 }
 
 func runGenerate(cmd *cobra.Command, args []string) error {
-	prompt, err := resolvePrompt(args)
+	prompt, err := resolvePrompt(optionalArg(args, 0), generatePromptFile)
 	if err != nil {
 		return err
 	}
@@ -207,41 +204,4 @@ func runGenerate(cmd *cobra.Command, args []string) error {
 	fmt.Printf("\nSuccessfully generated %d/%d images\n", successCount, generateCount)
 
 	return nil
-}
-
-func resolvePrompt(args []string) (string, error) {
-	hasArg := len(args) > 0
-	hasFile := generatePromptFile != ""
-
-	if hasArg && hasFile {
-		return "", fmt.Errorf("provide the prompt either as a positional argument or via --prompt-file, not both")
-	}
-	if hasArg {
-		return args[0], nil
-	}
-	if !hasFile {
-		return "", fmt.Errorf("a prompt is required: pass it as an argument or via --prompt-file")
-	}
-
-	var (
-		data []byte
-		err  error
-	)
-	if generatePromptFile == "-" {
-		data, err = io.ReadAll(os.Stdin)
-		if err != nil {
-			return "", fmt.Errorf("failed to read prompt from stdin: %w", err)
-		}
-	} else {
-		data, err = os.ReadFile(generatePromptFile)
-		if err != nil {
-			return "", fmt.Errorf("failed to read prompt file: %w", err)
-		}
-	}
-
-	prompt := strings.TrimSpace(string(data))
-	if prompt == "" {
-		return "", fmt.Errorf("prompt is empty")
-	}
-	return prompt, nil
 }

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -5,7 +5,10 @@ import (
 	"imagemage/pkg/filehandler"
 	"imagemage/pkg/gemini"
 	"imagemage/pkg/metadata"
+	"io"
+	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/spf13/cobra"
 )
@@ -22,6 +25,7 @@ var (
 	generateConfig      string
 	generateForce       bool
 	generateStorePrompt bool
+	generatePromptFile  string
 )
 
 var generateCmd = &cobra.Command{
@@ -38,8 +42,9 @@ Examples:
   imagemage generate "cyberpunk city" --style="neon, futuristic"
   imagemage generate "wide cinematic shot" --aspect-ratio="21:9"
   imagemage generate "phone wallpaper" --aspect-ratio="9:16"
-  imagemage generate "concept art" --frugal`,
-	Args: cobra.MinimumNArgs(1),
+  imagemage generate "concept art" --frugal
+  imagemage generate --prompt-file ./prompt.txt`,
+	Args: cobra.MaximumNArgs(1),
 	RunE: runGenerate,
 }
 
@@ -57,14 +62,17 @@ func init() {
 	generateCmd.Flags().StringVar(&generateConfig, "config", "", "Path to config file (JSON) with style, colorScheme, additionalContext")
 	generateCmd.Flags().BoolVar(&generateForce, "force", false, "Overwrite existing files without confirmation")
 	generateCmd.Flags().BoolVar(&generateStorePrompt, "store-prompt", false, "Store prompt in PNG metadata for reproducibility")
+	generateCmd.Flags().StringVar(&generatePromptFile, "prompt-file", "", "Read prompt from a file (use '-' for stdin)")
 }
 
 func runGenerate(cmd *cobra.Command, args []string) error {
-	prompt := args[0]
+	prompt, err := resolvePrompt(args)
+	if err != nil {
+		return err
+	}
 
 	// Load config if --slide or --config is specified
 	var config *gemini.ImageGenConfig
-	var err error
 	if generateSlide || generateConfig != "" {
 		config, err = gemini.FindConfig(generateConfig)
 		if err != nil {
@@ -199,4 +207,41 @@ func runGenerate(cmd *cobra.Command, args []string) error {
 	fmt.Printf("\nSuccessfully generated %d/%d images\n", successCount, generateCount)
 
 	return nil
+}
+
+func resolvePrompt(args []string) (string, error) {
+	hasArg := len(args) > 0
+	hasFile := generatePromptFile != ""
+
+	if hasArg && hasFile {
+		return "", fmt.Errorf("provide the prompt either as a positional argument or via --prompt-file, not both")
+	}
+	if hasArg {
+		return args[0], nil
+	}
+	if !hasFile {
+		return "", fmt.Errorf("a prompt is required: pass it as an argument or via --prompt-file")
+	}
+
+	var (
+		data []byte
+		err  error
+	)
+	if generatePromptFile == "-" {
+		data, err = io.ReadAll(os.Stdin)
+		if err != nil {
+			return "", fmt.Errorf("failed to read prompt from stdin: %w", err)
+		}
+	} else {
+		data, err = os.ReadFile(generatePromptFile)
+		if err != nil {
+			return "", fmt.Errorf("failed to read prompt file: %w", err)
+		}
+	}
+
+	prompt := strings.TrimSpace(string(data))
+	if prompt == "" {
+		return "", fmt.Errorf("prompt is empty")
+	}
+	return prompt, nil
 }

--- a/cmd/icon.go
+++ b/cmd/icon.go
@@ -31,7 +31,8 @@ Examples:
   imagemage icon "rocket ship" --sizes="64,128,256" --type="app-icon"
   imagemage icon "hamburger menu" --type="ui-element"
   imagemage icon "make this into a flat icon" -i logo.png
-  imagemage icon "simplify for app icon" -i photo.png --type="app-icon"`,
+  imagemage icon "simplify for app icon" -i photo.png --type="app-icon"
+  imagemage icon --prompt-file ./icon.txt`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: runIcon,
 }

--- a/cmd/icon.go
+++ b/cmd/icon.go
@@ -13,10 +13,11 @@ import (
 )
 
 var (
-	iconSizes  string
-	iconType   string
-	iconOutput string
-	iconInput  string
+	iconSizes      string
+	iconType       string
+	iconOutput     string
+	iconInput      string
+	iconPromptFile string
 )
 
 var iconCmd = &cobra.Command{
@@ -31,7 +32,7 @@ Examples:
   imagemage icon "hamburger menu" --type="ui-element"
   imagemage icon "make this into a flat icon" -i logo.png
   imagemage icon "simplify for app icon" -i photo.png --type="app-icon"`,
-	Args: cobra.MinimumNArgs(1),
+	Args: cobra.MaximumNArgs(1),
 	RunE: runIcon,
 }
 
@@ -42,10 +43,14 @@ func init() {
 	iconCmd.Flags().StringVar(&iconType, "type", "app-icon", "Icon type: app-icon, favicon, ui-element")
 	iconCmd.Flags().StringVarP(&iconOutput, "output", "o", ".", "Output directory for icons")
 	iconCmd.Flags().StringVarP(&iconInput, "input", "i", "", "Input image to convert to icon")
+	addPromptFileFlag(iconCmd, &iconPromptFile)
 }
 
 func runIcon(cmd *cobra.Command, args []string) error {
-	description := args[0]
+	description, err := resolvePrompt(optionalArg(args, 0), iconPromptFile)
+	if err != nil {
+		return err
+	}
 
 	// Parse sizes
 	sizeStrs := strings.Split(iconSizes, ",")

--- a/cmd/pattern.go
+++ b/cmd/pattern.go
@@ -10,9 +10,10 @@ import (
 )
 
 var (
-	patternType   string
-	patternStyle  string
-	patternOutput string
+	patternType       string
+	patternStyle      string
+	patternOutput     string
+	patternPromptFile string
 )
 
 var patternCmd = &cobra.Command{
@@ -24,7 +25,7 @@ Examples:
   imagemage pattern "geometric triangles"
   imagemage pattern "floral" --type="seamless" --style="watercolor"
   imagemage pattern "hexagons" --style="minimal, modern"`,
-	Args: cobra.MinimumNArgs(1),
+	Args: cobra.MaximumNArgs(1),
 	RunE: runPattern,
 }
 
@@ -34,10 +35,14 @@ func init() {
 	patternCmd.Flags().StringVar(&patternType, "type", "seamless", "Pattern type: seamless, tiled, texture")
 	patternCmd.Flags().StringVarP(&patternStyle, "style", "s", "", "Pattern style")
 	patternCmd.Flags().StringVarP(&patternOutput, "output", "o", ".", "Output directory")
+	addPromptFileFlag(patternCmd, &patternPromptFile)
 }
 
 func runPattern(cmd *cobra.Command, args []string) error {
-	description := args[0]
+	description, err := resolvePrompt(optionalArg(args, 0), patternPromptFile)
+	if err != nil {
+		return err
+	}
 
 	// Build prompt
 	prompt := fmt.Sprintf("Create a %s pattern: %s", patternType, description)

--- a/cmd/pattern.go
+++ b/cmd/pattern.go
@@ -24,7 +24,8 @@ var patternCmd = &cobra.Command{
 Examples:
   imagemage pattern "geometric triangles"
   imagemage pattern "floral" --type="seamless" --style="watercolor"
-  imagemage pattern "hexagons" --style="minimal, modern"`,
+  imagemage pattern "hexagons" --style="minimal, modern"
+  imagemage pattern --prompt-file ./pattern.txt`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: runPattern,
 }

--- a/cmd/prompt.go
+++ b/cmd/prompt.go
@@ -1,0 +1,58 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+func addPromptFileFlag(cmd *cobra.Command, target *string) {
+	cmd.Flags().StringVar(target, "prompt-file", "", "Read prompt from a file (use '-' for stdin)")
+}
+
+func resolvePrompt(positional, promptFile string) (string, error) {
+	hasArg := positional != ""
+	hasFile := promptFile != ""
+
+	if hasArg && hasFile {
+		return "", fmt.Errorf("provide the prompt either as a positional argument or via --prompt-file, not both")
+	}
+	if hasArg {
+		return positional, nil
+	}
+	if !hasFile {
+		return "", fmt.Errorf("a prompt is required: pass it as an argument or via --prompt-file")
+	}
+
+	var (
+		data []byte
+		err  error
+	)
+	if promptFile == "-" {
+		data, err = io.ReadAll(os.Stdin)
+		if err != nil {
+			return "", fmt.Errorf("failed to read prompt from stdin: %w", err)
+		}
+	} else {
+		data, err = os.ReadFile(promptFile)
+		if err != nil {
+			return "", fmt.Errorf("failed to read prompt file: %w", err)
+		}
+	}
+
+	prompt := strings.TrimSpace(string(data))
+	if prompt == "" {
+		return "", fmt.Errorf("prompt is empty")
+	}
+	return prompt, nil
+}
+
+func optionalArg(args []string, idx int) string {
+	if idx < len(args) {
+		return args[idx]
+	}
+	return ""
+}

--- a/cmd/story.go
+++ b/cmd/story.go
@@ -10,9 +10,10 @@ import (
 )
 
 var (
-	storyFrames int
-	storyOutput string
-	storyStyle  string
+	storyFrames     int
+	storyOutput     string
+	storyStyle      string
+	storyPromptFile string
 )
 
 var storyCmd = &cobra.Command{
@@ -24,7 +25,7 @@ Examples:
   imagemage story "a seed growing into a tree" --frames=4
   imagemage story "day to night transition in a city" --frames=6 --style="cinematic"
   imagemage story "character transformation" --frames=3`,
-	Args: cobra.MinimumNArgs(1),
+	Args: cobra.MaximumNArgs(1),
 	RunE: runStory,
 }
 
@@ -34,10 +35,14 @@ func init() {
 	storyCmd.Flags().IntVarP(&storyFrames, "frames", "f", 3, "Number of frames/scenes to generate")
 	storyCmd.Flags().StringVarP(&storyStyle, "style", "s", "", "Visual style for the story")
 	storyCmd.Flags().StringVarP(&storyOutput, "output", "o", ".", "Output directory")
+	addPromptFileFlag(storyCmd, &storyPromptFile)
 }
 
 func runStory(cmd *cobra.Command, args []string) error {
-	narrative := args[0]
+	narrative, err := resolvePrompt(optionalArg(args, 0), storyPromptFile)
+	if err != nil {
+		return err
+	}
 
 	if storyFrames < 2 {
 		return fmt.Errorf("frames must be at least 2")

--- a/cmd/story.go
+++ b/cmd/story.go
@@ -24,7 +24,8 @@ var storyCmd = &cobra.Command{
 Examples:
   imagemage story "a seed growing into a tree" --frames=4
   imagemage story "day to night transition in a city" --frames=6 --style="cinematic"
-  imagemage story "character transformation" --frames=3`,
+  imagemage story "character transformation" --frames=3
+  imagemage story --prompt-file ./narrative.txt`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: runStory,
 }


### PR DESCRIPTION
I needed to use this with a multiline, multi-paragraph prompt and it wasn't working, so I added a CLI flag to read the prompt from a file (or stdin).

The flag is now supported across all commands that take a prompt: `generate`, `diagram`, `icon`, `pattern`, `story`, and `edit` (for `edit`, the second positional `[instruction]` becomes optional). Pass `-` to read from stdin.

Example:

```
echo "isometric illustration of a coffee shop, watercolor style" | imagemage generate --prompt-file -
imagemage diagram --prompt-file ./diagram.txt
imagemage edit photo.png --prompt-file ./instruction.txt
```