### PR TITLE
Add batch generation and reference image support

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,14 @@ imagemage generate "a poster in this art style" -i style1.png -i style2.png
 - `--slide` - Optimized for presentation slides (4K, 16:9)
 - `--store-prompt` - Save the prompt in the image metadata (for reproducibility)
 
+**OpenAI-only Options** (ignored by Gemini, which warns if you set them):
+- `--background` - `transparent`, `opaque`, or `auto`. Transparent requires `--format=png` or `webp`. Great for icons and logos.
+- `--fidelity` - `high` or `low`. With reference/edit images, `high` preserves faces, logos, and fine detail more faithfully.
+- `--moderation` - `low` or `auto`. Relaxes the content filter when appropriate.
+- `--compression` - `0`-`100` output compression for `jpeg`/`webp`.
+
+With OpenAI, `--count` requests all images in a single batched API call (`n`), rather than one call per image.
+
 **Supported Aspect Ratios:**
 - **Square:** 1:1 (1024x1024) - The default, for some reason
 - **Landscape:** 16:9 (1344x768), 4:3, 3:2, 21:9 - For when you want it wider

--- a/README.md
+++ b/README.md
@@ -119,10 +119,15 @@ imagemage generate "concept art" --quality=low --count=5
 
 # Use Gemini instead of OpenAI
 imagemage generate "concept art" --provider=gemini
+
+# Condition generation on reference image(s) without editing them
+imagemage generate "this character riding a bike" --reference char.png
+imagemage generate "a poster in this art style" -i style1.png -i style2.png
 ```
 
 **Useful Flags:**
 - `-c, --count` - Number of images to generate (default: 1)
+- `-i, --reference` - Reference image(s) to condition generation on (can be used multiple times)
 - `-o, --output` - Output directory (default: current directory, because obviously)
 - `-s, --style` - Additional style guidance for when your prompt needs more... guidance
 - `-a, --aspect-ratio` - Aspect ratio (1:1, 16:9, 9:16, 4:3, 3:4, 3:2, 2:3, 21:9, 5:4, 4:5)

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -169,28 +169,44 @@ func runGenerate(cmd *cobra.Command, args []string) error {
 	fmt.Printf("Quality: %s\n", generationRequest("", "", "", nil, generateFrugal).Quality)
 	fmt.Println()
 
-	successCount := 0
 	ctx := context.Background()
-	for i := 1; i <= generateCount; i++ {
-		if generateCount > 1 {
-			fmt.Printf("[%d/%d] Generating image...\n", i, generateCount)
-		} else {
-			fmt.Println("Generating image...")
-		}
+	req := generationRequest(fullPrompt, generateResolution, generateAspectRatio, references, generateFrugal)
 
-		req := generationRequest(fullPrompt, generateResolution, generateAspectRatio, references, generateFrugal)
-		// providerAction routes to the reference-capable Edit path when
-		// references are present, and to plain text-to-image otherwise.
-		result, err := providerAction(ctx, client, req)
+	// Collect results. When the provider supports batching (OpenAI's `n`), ask
+	// for all images in a single API call; otherwise fall back to one call per
+	// image (Gemini returns one image per request). providerAction routes to the
+	// reference-capable Edit path when references are present.
+	var results []imagegen.Result
+	if bg, ok := client.(imagegen.BatchGenerator); ok && generateCount > 1 {
+		fmt.Printf("Requesting %d images in a single call...\n", generateCount)
+		batchReq := req
+		batchReq.Count = generateCount
+		results, err = bg.GenerateBatch(ctx, batchReq)
 		if err != nil {
-			fmt.Printf("Error generating image %d: %v\n", i, err)
-			continue
+			return fmt.Errorf("failed to generate images: %w", err)
 		}
+	} else {
+		for i := 1; i <= generateCount; i++ {
+			if generateCount > 1 {
+				fmt.Printf("[%d/%d] Generating image...\n", i, generateCount)
+			} else {
+				fmt.Println("Generating image...")
+			}
+			result, err := providerAction(ctx, client, req)
+			if err != nil {
+				fmt.Printf("Error generating image %d: %v\n", i, err)
+				continue
+			}
+			results = append(results, result)
+		}
+	}
 
+	successCount := 0
+	for idx, result := range results {
 		// Generate filename (prefer AI-suggested name)
 		var filename string
 		if generateCount > 1 {
-			filename = filehandler.GenerateFilename(prompt, result.SuggestedName, "", i)
+			filename = filehandler.GenerateFilename(prompt, result.SuggestedName, "", idx+1)
 		} else {
 			filename = filehandler.GenerateFilename(prompt, result.SuggestedName, "", 0)
 		}
@@ -202,7 +218,7 @@ func runGenerate(cmd *cobra.Command, args []string) error {
 
 		// Save image
 		if err := filehandler.SaveImage(result.ImageData, outputPath); err != nil {
-			fmt.Printf("Error saving image %d: %v\n", i, err)
+			fmt.Printf("Error saving image %d: %v\n", idx+1, err)
 			continue
 		}
 

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -7,6 +7,7 @@ import (
 	"imagemage/pkg/gemini"
 	"imagemage/pkg/imagegen"
 	"imagemage/pkg/metadata"
+	"os"
 	"path/filepath"
 
 	"github.com/spf13/cobra"
@@ -24,6 +25,7 @@ var (
 	generateConfig      string
 	generateForce       bool
 	generateStorePrompt bool
+	generateReferences  []string
 )
 
 var generateCmd = &cobra.Command{
@@ -35,13 +37,19 @@ By default, uses OpenAI Images via gpt-image-2. Use --provider=gemini to use Gem
 image models. The --frugal flag is a deprecated low-cost alias; with Gemini it
 selects Nano Banana 2 (gemini-3.1-flash-image-preview).
 
+Reference images can guide generation: pass one or more with --reference to
+condition the output on existing imagery (style, subject, composition) without
+editing those images directly. This works on both providers.
+
 Examples:
   imagemage generate "watercolor painting of a fox in snowy forest"
   imagemage generate "mountain landscape" --count=3 --output=./images
   imagemage generate "cyberpunk city" --style="neon, futuristic"
   imagemage generate "wide cinematic shot" --aspect-ratio="21:9"
   imagemage generate "phone wallpaper" --aspect-ratio="9:16"
-  imagemage generate "concept art" --frugal`,
+  imagemage generate "concept art" --frugal
+  imagemage generate "this character riding a bike" --reference char.png
+  imagemage generate "a poster in this art style" -i style1.png -i style2.png`,
 	Args: cobra.MinimumNArgs(1),
 	RunE: runGenerate,
 }
@@ -60,6 +68,7 @@ func init() {
 	generateCmd.Flags().StringVar(&generateConfig, "config", "", "Path to config file (JSON) with style, colorScheme, additionalContext")
 	generateCmd.Flags().BoolVar(&generateForce, "force", false, "Overwrite existing files without confirmation")
 	generateCmd.Flags().BoolVar(&generateStorePrompt, "store-prompt", false, "Store prompt in PNG metadata for reproducibility")
+	generateCmd.Flags().StringArrayVarP(&generateReferences, "reference", "i", []string{}, "Reference image(s) to condition generation on (can be used multiple times)")
 }
 
 func runGenerate(cmd *cobra.Command, args []string) error {
@@ -113,6 +122,23 @@ func runGenerate(cmd *cobra.Command, args []string) error {
 		fullPrompt = config.ApplyToPrompt(fullPrompt)
 	}
 
+	// Load reference images if provided. References condition generation but,
+	// unlike `edit`, are not themselves modified in place.
+	var references []imagegen.ImageInput
+	for _, refPath := range generateReferences {
+		if _, err := os.Stat(refPath); os.IsNotExist(err) {
+			return fmt.Errorf("reference image not found: %s", refPath)
+		}
+		ref, err := loadImageInput(refPath)
+		if err != nil {
+			return fmt.Errorf("failed to load reference image %s: %w", refPath, err)
+		}
+		references = append(references, ref)
+	}
+	if len(references) > 14 {
+		return fmt.Errorf("too many reference images (%d). Maximum is 14", len(references))
+	}
+
 	client, provider, model, err := newImageClient(generateFrugal)
 	if err != nil {
 		return fmt.Errorf("failed to create image client: %w", err)
@@ -120,6 +146,9 @@ func runGenerate(cmd *cobra.Command, args []string) error {
 
 	// Display generation info
 	fmt.Printf("Generating %d image(s) for: %s\n", generateCount, prompt)
+	if len(references) > 0 {
+		fmt.Printf("Reference images: %d\n", len(references))
+	}
 	if config != nil {
 		fmt.Printf("Config: Loaded (theme applied to prompt)\n")
 	}
@@ -149,8 +178,10 @@ func runGenerate(cmd *cobra.Command, args []string) error {
 			fmt.Println("Generating image...")
 		}
 
-		req := generationRequest(fullPrompt, generateResolution, generateAspectRatio, nil, generateFrugal)
-		result, err := client.Generate(ctx, req)
+		req := generationRequest(fullPrompt, generateResolution, generateAspectRatio, references, generateFrugal)
+		// providerAction routes to the reference-capable Edit path when
+		// references are present, and to plain text-to-image otherwise.
+		result, err := providerAction(ctx, client, req)
 		if err != nil {
 			fmt.Printf("Error generating image %d: %v\n", i, err)
 			continue

--- a/cmd/provider.go
+++ b/cmd/provider.go
@@ -15,10 +15,14 @@ import (
 )
 
 var (
-	cliProvider string
-	cliModel    string
-	cliQuality  string
-	cliFormat   string
+	cliProvider    string
+	cliModel       string
+	cliQuality     string
+	cliFormat      string
+	cliBackground  string
+	cliFidelity    string
+	cliModeration  string
+	cliCompression int
 )
 
 func init() {
@@ -26,6 +30,10 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&cliModel, "model", "", "Provider model override")
 	rootCmd.PersistentFlags().StringVar(&cliQuality, "quality", "auto", "Generation quality: low, medium, high, auto")
 	rootCmd.PersistentFlags().StringVar(&cliFormat, "format", "png", "Output format for providers that support it: png, jpeg, webp")
+	rootCmd.PersistentFlags().StringVar(&cliBackground, "background", "", "Background (OpenAI): transparent, opaque, auto. Transparent requires png/webp")
+	rootCmd.PersistentFlags().StringVar(&cliFidelity, "fidelity", "", "Input fidelity for reference/edit images (OpenAI): high or low")
+	rootCmd.PersistentFlags().StringVar(&cliModeration, "moderation", "", "Moderation strictness (OpenAI): low or auto")
+	rootCmd.PersistentFlags().IntVar(&cliCompression, "compression", 0, "Output compression 0-100 for jpeg/webp (OpenAI)")
 }
 
 func newImageClient(frugal bool) (imagegen.Client, imagegen.Provider, string, error) {
@@ -46,6 +54,9 @@ func newImageClient(frugal bool) (imagegen.Client, imagegen.Provider, string, er
 		client, err := openai.NewClient(model)
 		return client, provider, model, err
 	case imagegen.ProviderGemini:
+		if cliBackground != "" || cliFidelity != "" || cliModeration != "" || cliCompression != 0 {
+			fmt.Fprintln(os.Stderr, "⚠️  --background/--fidelity/--moderation/--compression are OpenAI-only and ignored by Gemini")
+		}
 		if model == "" && frugal {
 			model = gemini.ModelNameFrugal
 		}
@@ -65,12 +76,16 @@ func generationRequest(prompt, resolution, aspectRatio string, images []imagegen
 		quality = "low"
 	}
 	return imagegen.Request{
-		Prompt:       prompt,
-		Images:       images,
-		AspectRatio:  aspectRatio,
-		Resolution:   resolution,
-		Quality:      quality,
-		OutputFormat: cliFormat,
+		Prompt:        prompt,
+		Images:        images,
+		AspectRatio:   aspectRatio,
+		Resolution:    resolution,
+		Quality:       quality,
+		OutputFormat:  cliFormat,
+		Background:    cliBackground,
+		InputFidelity: cliFidelity,
+		Moderation:    cliModeration,
+		Compression:   cliCompression,
 	}
 }
 

--- a/pkg/filehandler/filehandler.go
+++ b/pkg/filehandler/filehandler.go
@@ -69,7 +69,10 @@ func GenerateFilename(prompt, suggestedName, prefix string, count int) string {
 		filename = fmt.Sprintf("%s_%d", filename, count)
 	}
 
-	return filename + ".png"
+	// Sanitize the fully assembled stem (not just the prompt/suggested-name
+	// part) so an unsanitized prefix can't reintroduce runs like "foo--bar"
+	// that break some markdown renderers.
+	return SanitizeFilenameStem(filename) + ".png"
 }
 
 // cleanPrompt converts a prompt into a filename-safe string

--- a/pkg/filehandler/filehandler_test.go
+++ b/pkg/filehandler/filehandler_test.go
@@ -142,6 +142,14 @@ func TestGenerateFilename(t *testing.T) {
 			expected:      "pattern_geometric_pattern.png",
 		},
 		{
+			name:          "collapses double dashes from unsanitized prefix",
+			prompt:        "circuit board",
+			suggestedName: "",
+			prefix:        "flow--chart",
+			count:         0,
+			expected:      "flow-chart_circuit_board.png",
+		},
+		{
 			name:          "adds count when specified",
 			prompt:        "mountain landscape",
 			suggestedName: "alpine vista",

--- a/pkg/imagegen/imagegen.go
+++ b/pkg/imagegen/imagegen.go
@@ -24,6 +24,20 @@ type Request struct {
 	Resolution   string
 	Quality      string
 	OutputFormat string
+	// Background controls transparency: "transparent", "opaque", or "auto".
+	// Transparent output requires a format that supports it (png or webp).
+	Background string
+	// InputFidelity asks the model to preserve detail from input images
+	// ("high" or "low"). Only meaningful when Images are supplied.
+	InputFidelity string
+	// Moderation selects the content-moderation strictness: "low" or "auto".
+	Moderation string
+	// Compression is the output compression (0-100) for lossy formats
+	// (jpeg, webp). Zero means "leave unset / provider default".
+	Compression int
+	// Count is the number of images to request in a single batched call.
+	// Zero or one means a single image. Only honored by BatchGenerator.
+	Count int
 }
 
 type Result struct {
@@ -36,6 +50,16 @@ type Result struct {
 type Client interface {
 	Generate(ctx context.Context, req Request) (Result, error)
 	Edit(ctx context.Context, req Request) (Result, error)
+}
+
+// BatchGenerator is an optional capability for providers that can return
+// multiple images from a single API call (e.g. OpenAI's `n` parameter).
+// Callers should type-assert against it and fall back to repeated Generate/Edit
+// calls for providers that do not implement it (such as Gemini, which returns
+// one image per request). It routes to the reference-capable edit path when
+// req.Images is non-empty, mirroring providerAction.
+type BatchGenerator interface {
+	GenerateBatch(ctx context.Context, req Request) ([]Result, error)
 }
 
 var SupportedAspectRatios = []string{

--- a/pkg/openai/client.go
+++ b/pkg/openai/client.go
@@ -72,47 +72,92 @@ func NewClient(model string, opts ...Option) (*Client, error) {
 }
 
 func (c *Client) Generate(ctx context.Context, req imagegen.Request) (imagegen.Result, error) {
-	size, err := normalizeSize(req)
+	results, err := c.generate(ctx, req, 1)
 	if err != nil {
 		return imagegen.Result{}, err
 	}
-	body := generationRequest{
-		Model:        c.model,
-		Prompt:       req.Prompt,
-		Size:         size,
-		Quality:      normalizeQuality(req.Quality),
-		OutputFormat: normalizeOutputFormat(req.OutputFormat),
-		N:            1,
-	}
-	return c.postJSON(ctx, "/generations", body)
+	return results[0], nil
 }
 
 func (c *Client) Edit(ctx context.Context, req imagegen.Request) (imagegen.Result, error) {
 	if len(req.Images) == 0 {
 		return c.Generate(ctx, req)
 	}
+	results, err := c.edit(ctx, req, 1)
+	if err != nil {
+		return imagegen.Result{}, err
+	}
+	return results[0], nil
+}
+
+// GenerateBatch implements imagegen.BatchGenerator, requesting up to req.Count
+// images in a single API call via the `n` parameter. It routes to the edits
+// endpoint when reference images are present, otherwise to generations.
+func (c *Client) GenerateBatch(ctx context.Context, req imagegen.Request) ([]imagegen.Result, error) {
+	n := req.Count
+	if n < 1 {
+		n = 1
+	}
+	if len(req.Images) > 0 {
+		return c.edit(ctx, req, n)
+	}
+	return c.generate(ctx, req, n)
+}
+
+func (c *Client) generate(ctx context.Context, req imagegen.Request, n int) ([]imagegen.Result, error) {
+	size, err := normalizeSize(req)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateBackground(req); err != nil {
+		return nil, err
+	}
+	body := generationRequest{
+		Model:             c.model,
+		Prompt:            req.Prompt,
+		Size:              size,
+		Quality:           normalizeQuality(req.Quality),
+		OutputFormat:      normalizeOutputFormat(req.OutputFormat),
+		Background:        normalizeBackground(req.Background),
+		Moderation:        normalizeModeration(req.Moderation),
+		OutputCompression: normalizeCompression(req),
+		N:                 n,
+	}
+	return c.postJSON(ctx, "/generations", body)
+}
+
+func (c *Client) edit(ctx context.Context, req imagegen.Request, n int) ([]imagegen.Result, error) {
+	if err := validateBackground(req); err != nil {
+		return nil, err
+	}
 
 	var body bytes.Buffer
 	writer := multipart.NewWriter(&body)
 	size, err := normalizeSize(req)
 	if err != nil {
-		return imagegen.Result{}, err
+		return nil, err
 	}
 
 	fields := map[string]string{
-		"model":         c.model,
-		"prompt":        req.Prompt,
-		"size":          size,
-		"quality":       normalizeQuality(req.Quality),
-		"output_format": normalizeOutputFormat(req.OutputFormat),
-		"n":             "1",
+		"model":          c.model,
+		"prompt":         req.Prompt,
+		"size":           size,
+		"quality":        normalizeQuality(req.Quality),
+		"output_format":  normalizeOutputFormat(req.OutputFormat),
+		"background":     normalizeBackground(req.Background),
+		"input_fidelity": normalizeFidelity(req.InputFidelity),
+		"moderation":     normalizeModeration(req.Moderation),
+		"n":              fmt.Sprintf("%d", n),
+	}
+	if comp := normalizeCompression(req); comp != nil {
+		fields["output_compression"] = fmt.Sprintf("%d", *comp)
 	}
 	for k, v := range fields {
 		if v == "" {
 			continue
 		}
 		if err := writer.WriteField(k, v); err != nil {
-			return imagegen.Result{}, fmt.Errorf("failed to write form field %s: %w", k, err)
+			return nil, fmt.Errorf("failed to write form field %s: %w", k, err)
 		}
 	}
 
@@ -132,19 +177,19 @@ func (c *Client) Edit(ctx context.Context, req imagegen.Request) (imagegen.Resul
 		header.Set("Content-Type", mimeType)
 		part, err := writer.CreatePart(header)
 		if err != nil {
-			return imagegen.Result{}, fmt.Errorf("failed to create image form part: %w", err)
+			return nil, fmt.Errorf("failed to create image form part: %w", err)
 		}
 		decoded, err := base64.StdEncoding.DecodeString(img.Base64)
 		if err != nil {
-			return imagegen.Result{}, fmt.Errorf("failed to decode input image %d: %w", i+1, err)
+			return nil, fmt.Errorf("failed to decode input image %d: %w", i+1, err)
 		}
 		if _, err := part.Write(decoded); err != nil {
-			return imagegen.Result{}, fmt.Errorf("failed to write image form part: %w", err)
+			return nil, fmt.Errorf("failed to write image form part: %w", err)
 		}
 	}
 
 	if err := writer.Close(); err != nil {
-		return imagegen.Result{}, fmt.Errorf("failed to close multipart body: %w", err)
+		return nil, fmt.Errorf("failed to close multipart body: %w", err)
 	}
 
 	return c.do(ctx, http.MethodPost, c.baseURL+"/edits", writer.FormDataContentType(), body.Bytes())
@@ -179,6 +224,65 @@ func normalizeOutputFormat(format string) string {
 	}
 }
 
+// normalizeBackground returns "transparent"/"opaque" to be sent verbatim, or
+// "" for the default ("auto"), which we omit so the API applies its default.
+func normalizeBackground(background string) string {
+	switch background {
+	case "transparent", "opaque":
+		return background
+	default:
+		return ""
+	}
+}
+
+// normalizeFidelity returns "high"/"low" or "" to omit (API defaults to low).
+func normalizeFidelity(fidelity string) string {
+	switch fidelity {
+	case "high", "low":
+		return fidelity
+	default:
+		return ""
+	}
+}
+
+// normalizeModeration returns "low" to relax moderation, or "" to omit so the
+// API applies its default ("auto").
+func normalizeModeration(moderation string) string {
+	if moderation == "low" {
+		return "low"
+	}
+	return ""
+}
+
+// normalizeCompression returns the output_compression value to send, or nil to
+// omit it. Compression only applies to lossy formats (jpeg, webp).
+func normalizeCompression(req imagegen.Request) *int {
+	if req.Compression <= 0 || req.Compression > 100 {
+		return nil
+	}
+	switch normalizeOutputFormat(req.OutputFormat) {
+	case "jpeg", "webp":
+		c := req.Compression
+		return &c
+	default:
+		return nil
+	}
+}
+
+// validateBackground guards the documented constraint that transparent
+// backgrounds require a format that supports transparency (png or webp).
+func validateBackground(req imagegen.Request) error {
+	if req.Background != "transparent" {
+		return nil
+	}
+	switch normalizeOutputFormat(req.OutputFormat) {
+	case "png", "webp":
+		return nil
+	default:
+		return fmt.Errorf("transparent background requires png or webp output, got %q", req.OutputFormat)
+	}
+}
+
 func extensionForMime(mimeType string) string {
 	switch mimeType {
 	case "image/jpeg":
@@ -190,10 +294,10 @@ func extensionForMime(mimeType string) string {
 	}
 }
 
-func (c *Client) postJSON(ctx context.Context, path string, body generationRequest) (imagegen.Result, error) {
+func (c *Client) postJSON(ctx context.Context, path string, body generationRequest) ([]imagegen.Result, error) {
 	jsonData, err := json.Marshal(body)
 	if err != nil {
-		return imagegen.Result{}, fmt.Errorf("failed to marshal request: %w", err)
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
 	}
 
 	if os.Getenv("DEBUG") != "" {
@@ -203,27 +307,27 @@ func (c *Client) postJSON(ctx context.Context, path string, body generationReque
 	return c.do(ctx, http.MethodPost, c.baseURL+path, "application/json", jsonData)
 }
 
-func (c *Client) do(ctx context.Context, method, url, contentType string, body []byte) (imagegen.Result, error) {
+func (c *Client) do(ctx context.Context, method, url, contentType string, body []byte) ([]imagegen.Result, error) {
 	const maxRetries = 3
 	var lastErr error
 
 	for attempt := 1; attempt <= maxRetries; attempt++ {
 		req, err := http.NewRequestWithContext(ctx, method, url, bytes.NewReader(body))
 		if err != nil {
-			return imagegen.Result{}, fmt.Errorf("failed to create request: %w", err)
+			return nil, fmt.Errorf("failed to create request: %w", err)
 		}
 		req.Header.Set("Authorization", "Bearer "+c.apiKey)
 		req.Header.Set("Content-Type", contentType)
 
 		resp, err := c.httpClient.Do(req)
 		if err != nil {
-			return imagegen.Result{}, fmt.Errorf("failed to send request: %w", err)
+			return nil, fmt.Errorf("failed to send request: %w", err)
 		}
 
 		body, err := io.ReadAll(resp.Body)
 		_ = resp.Body.Close()
 		if err != nil {
-			return imagegen.Result{}, fmt.Errorf("failed to read response: %w", err)
+			return nil, fmt.Errorf("failed to read response: %w", err)
 		}
 
 		if os.Getenv("DEBUG") != "" {
@@ -232,7 +336,7 @@ func (c *Client) do(ctx context.Context, method, url, contentType string, body [
 		}
 
 		if resp.StatusCode == http.StatusOK {
-			return c.extractResult(body)
+			return c.extractResults(body)
 		}
 
 		lastErr = c.handleError(resp.StatusCode, body)
@@ -240,37 +344,47 @@ func (c *Client) do(ctx context.Context, method, url, contentType string, body [
 			time.Sleep(time.Duration(attempt) * time.Second)
 			continue
 		}
-		return imagegen.Result{}, lastErr
+		return nil, lastErr
 	}
 
-	return imagegen.Result{}, lastErr
+	return nil, lastErr
 }
 
-func (c *Client) extractResult(body []byte) (imagegen.Result, error) {
+func (c *Client) extractResults(body []byte) ([]imagegen.Result, error) {
 	var result imageResponse
 	if err := json.Unmarshal(body, &result); err != nil {
-		return imagegen.Result{}, fmt.Errorf("failed to unmarshal response: %w", err)
+		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
 	}
-	if len(result.Data) == 0 || result.Data[0].B64JSON == "" {
-		return imagegen.Result{}, fmt.Errorf("no image data found in response")
+	if len(result.Data) == 0 {
+		return nil, fmt.Errorf("no image data found in response")
 	}
-	// Strip C2PA / XMP / EXIF before handing the image to downstream code so
-	// platforms like LinkedIn and Twitter don't auto-label posts as AI-generated
-	// from embedded provenance manifests. SynthID is a pixel-domain watermark
-	// and is unaffected.
-	decoded, err := base64.StdEncoding.DecodeString(result.Data[0].B64JSON)
-	if err != nil {
-		return imagegen.Result{}, fmt.Errorf("failed to decode image data: %w", err)
+	results := make([]imagegen.Result, 0, len(result.Data))
+	for _, d := range result.Data {
+		if d.B64JSON == "" {
+			continue
+		}
+		// Strip C2PA / XMP / EXIF before handing the image to downstream code so
+		// platforms like LinkedIn and Twitter don't auto-label posts as AI-generated
+		// from embedded provenance manifests. SynthID is a pixel-domain watermark
+		// and is unaffected.
+		decoded, err := base64.StdEncoding.DecodeString(d.B64JSON)
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode image data: %w", err)
+		}
+		stripped, err := metadata.StripProvenance(decoded)
+		if err != nil {
+			return nil, fmt.Errorf("failed to strip provenance metadata: %w", err)
+		}
+		results = append(results, imagegen.Result{
+			ImageData: base64.StdEncoding.EncodeToString(stripped),
+			Provider:  imagegen.ProviderOpenAI,
+			Model:     c.model,
+		})
 	}
-	stripped, err := metadata.StripProvenance(decoded)
-	if err != nil {
-		return imagegen.Result{}, fmt.Errorf("failed to strip provenance metadata: %w", err)
+	if len(results) == 0 {
+		return nil, fmt.Errorf("no image data found in response")
 	}
-	return imagegen.Result{
-		ImageData: base64.StdEncoding.EncodeToString(stripped),
-		Provider:  imagegen.ProviderOpenAI,
-		Model:     c.model,
-	}, nil
+	return results, nil
 }
 
 func (c *Client) handleError(statusCode int, body []byte) error {
@@ -295,12 +409,15 @@ func (c *Client) handleError(statusCode int, body []byte) error {
 }
 
 type generationRequest struct {
-	Model        string `json:"model"`
-	Prompt       string `json:"prompt"`
-	Size         string `json:"size,omitempty"`
-	Quality      string `json:"quality,omitempty"`
-	OutputFormat string `json:"output_format,omitempty"`
-	N            int    `json:"n,omitempty"`
+	Model             string `json:"model"`
+	Prompt            string `json:"prompt"`
+	Size              string `json:"size,omitempty"`
+	Quality           string `json:"quality,omitempty"`
+	OutputFormat      string `json:"output_format,omitempty"`
+	Background        string `json:"background,omitempty"`
+	Moderation        string `json:"moderation,omitempty"`
+	OutputCompression *int   `json:"output_compression,omitempty"`
+	N                 int    `json:"n,omitempty"`
 }
 
 type imageResponse struct {

--- a/pkg/openai/client_test.go
+++ b/pkg/openai/client_test.go
@@ -179,6 +179,108 @@ func TestGenerateRetriesWithFreshBody(t *testing.T) {
 	}
 }
 
+func TestGenerateBatchRequestsMultiple(t *testing.T) {
+	var reqBody map[string]any
+	httpClient := roundTripClient(func(r *http.Request) (*http.Response, error) {
+		if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
+			t.Fatalf("failed to decode request: %v", err)
+		}
+		return jsonResponse(http.StatusOK, `{"data":[{"b64_json":"`+tinyPNGBase64+`"},{"b64_json":"`+tinyPNGBase64+`"},{"b64_json":"`+tinyPNGBase64+`"}]}`), nil
+	})
+
+	client, err := openai.NewClient("test-image-model", openai.WithAPIKey("test-key"), openai.WithBaseURL("https://example.test/v1/images"), openai.WithHTTPClient(httpClient))
+	if err != nil {
+		t.Fatalf("unexpected client error: %v", err)
+	}
+
+	results, err := client.GenerateBatch(context.Background(), imagegen.Request{Prompt: "three at once", Count: 3})
+	if err != nil {
+		t.Fatalf("unexpected batch error: %v", err)
+	}
+	if len(results) != 3 {
+		t.Fatalf("expected 3 results, got %d", len(results))
+	}
+	if n, _ := reqBody["n"].(float64); n != 3 {
+		t.Fatalf("expected n=3 in request, got %v", reqBody["n"])
+	}
+}
+
+func TestGenerateSendsBackgroundAndModeration(t *testing.T) {
+	var reqBody map[string]any
+	httpClient := roundTripClient(func(r *http.Request) (*http.Response, error) {
+		_ = json.NewDecoder(r.Body).Decode(&reqBody)
+		return jsonResponse(http.StatusOK, `{"data":[{"b64_json":"`+tinyPNGBase64+`"}]}`), nil
+	})
+	client, _ := openai.NewClient("test-image-model", openai.WithAPIKey("test-key"), openai.WithBaseURL("https://example.test/v1/images"), openai.WithHTTPClient(httpClient))
+
+	_, err := client.Generate(context.Background(), imagegen.Request{
+		Prompt:       "logo",
+		OutputFormat: "png",
+		Background:   "transparent",
+		Moderation:   "low",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertField(t, reqBody, "background", "transparent")
+	assertField(t, reqBody, "moderation", "low")
+}
+
+func TestTransparentBackgroundRejectsJPEG(t *testing.T) {
+	client, _ := openai.NewClient("test-image-model", openai.WithAPIKey("test-key"), openai.WithBaseURL("https://example.test/v1/images"))
+	_, err := client.Generate(context.Background(), imagegen.Request{
+		Prompt:       "logo",
+		OutputFormat: "jpeg",
+		Background:   "transparent",
+	})
+	if err == nil || !strings.Contains(err.Error(), "transparent background requires png or webp") {
+		t.Fatalf("expected transparent/jpeg validation error, got %v", err)
+	}
+}
+
+func TestEditSendsFidelityAndCompression(t *testing.T) {
+	gotFields := map[string]string{}
+	httpClient := roundTripClient(func(r *http.Request) (*http.Response, error) {
+		reader, err := r.MultipartReader()
+		if err != nil {
+			t.Fatalf("expected multipart: %v", err)
+		}
+		for {
+			part, err := reader.NextPart()
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				t.Fatalf("multipart read error: %v", err)
+			}
+			if part.FormName() == "image[]" {
+				continue
+			}
+			data, _ := io.ReadAll(part)
+			gotFields[part.FormName()] = string(data)
+		}
+		return jsonResponse(http.StatusOK, `{"data":[{"b64_json":"`+tinyPNGBase64+`"}]}`), nil
+	})
+	client, _ := openai.NewClient("test-image-model", openai.WithAPIKey("test-key"), openai.WithBaseURL("https://example.test/v1/images"), openai.WithHTTPClient(httpClient))
+
+	_, err := client.Edit(context.Background(), imagegen.Request{
+		Prompt:        "preserve the face",
+		OutputFormat:  "webp",
+		InputFidelity: "high",
+		Compression:   80,
+		Images:        []imagegen.ImageInput{{MimeType: "image/png", Base64: tinyPNGBase64}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected edit error: %v", err)
+	}
+	if gotFields["input_fidelity"] != "high" {
+		t.Fatalf("expected input_fidelity=high, got %q", gotFields["input_fidelity"])
+	}
+	if gotFields["output_compression"] != "80" {
+		t.Fatalf("expected output_compression=80, got %q", gotFields["output_compression"])
+	}
+}
+
 func assertField(t *testing.T, body map[string]any, field string, want string) {
 	t.Helper()
 	got, ok := body[field].(string)


### PR DESCRIPTION
## Summary
This PR adds support for batch image generation and reference images to condition generation without editing. It refactors the OpenAI client to support requesting multiple images in a single API call via the `n` parameter, and introduces new OpenAI-specific options for background, fidelity, moderation, and compression control.

## Key Changes

**Batch Generation:**
- Introduce `BatchGenerator` interface for providers that support multiple images per API call
- Implement `GenerateBatch()` in OpenAI client to request up to `req.Count` images in a single call
- Refactor `Generate()` and `Edit()` to delegate to internal `generate()` and `edit()` methods that accept an `n` parameter
- Update CLI to use batch generation when available and `--count > 1`, falling back to sequential calls for providers like Gemini

**Reference Images:**
- Add `--reference` / `-i` flag to `generate` command to pass conditioning images without editing them
- Support up to 14 reference images per request
- Reference images work with both OpenAI and Gemini providers
- Implement `providerAction()` helper to route to Edit path when references are present

**OpenAI-Specific Features:**
- Add `--background` flag: `transparent`, `opaque`, or `auto` (transparent requires png/webp format)
- Add `--fidelity` flag: `high` or `low` for input image detail preservation
- Add `--moderation` flag: `low` or `auto` for content moderation strictness
- Add `--compression` flag: 0-100 compression level for jpeg/webp formats
- Implement validation that transparent backgrounds require png or webp output
- Add normalization functions for all new parameters with sensible defaults

**Response Handling:**
- Change internal methods to return `[]imagegen.Result` instead of single `imagegen.Result`
- Update `extractResult()` to `extractResults()` to handle multiple images from API response
- Properly handle cases where some images in a batch response may be empty

**Filename Generation:**
- Fix `GenerateFilename()` to sanitize the complete filename stem (including prefix) to prevent double-dash artifacts that break markdown renderers

**Testing:**
- Add `TestGenerateBatchRequestsMultiple()` to verify batch requests with `n=3`
- Add `TestGenerateSendsBackgroundAndModeration()` to verify new parameters are sent
- Add `TestTransparentBackgroundRejectsJPEG()` to verify validation
- Add `TestEditSendsFidelityAndCompression()` to verify edit-specific parameters
- Add test case for filename sanitization with unsanitized prefix

## Implementation Details

- The refactored `generate()` and `edit()` methods now accept an `n` parameter, allowing both single and batch operations
- Batch generation is only used when the client implements `BatchGenerator` and `--count > 1`; otherwise falls back to sequential calls
- Reference images are loaded from disk and validated before making API calls
- OpenAI-specific flags warn users when used with Gemini provider
- All new parameters are optional and omitted from requests when not set, allowing the API to apply defaults

https://claude.ai/code/session_01DtyqJhiV624LgPbRK2FQqA